### PR TITLE
Change MQTT endpoint & root CA certificate source

### DIFF
--- a/iotsoftbox-core/loc_core.c
+++ b/iotsoftbox-core/loc_core.c
@@ -50,7 +50,7 @@
 #define LOC_MQTT_USER_NAME            "json+device"
 
 #ifndef LOC_SERV_HOST_NAME
-#define LOC_SERV_HOST_NAME           "liveobjects.orange-business.com"
+#define LOC_SERV_HOST_NAME           "mqtt.liveobjects.orange-business.com"
 #endif
 
 #ifndef LOC_SERV_IP_ADDRESS
@@ -140,7 +140,7 @@ static struct {
 #if SECURITY_ENABLED
 
 static LiveObjectsSecurityParams_t _LOClient_params_security = {
-		{ 0, SERVER_CERT },
+		{ 1, SERVER_CERTS },
 		{ 0, CLIENT_CERT },
 		{ 0, CLIENT_PKEY },
 		SERVER_CERTIFICATE_COMMON_NAME,

--- a/templates-config/liveobjects_dev_security.h.txt
+++ b/templates-config/liveobjects_dev_security.h.txt
@@ -19,50 +19,15 @@
 
 #define VERIFY_MODE   0
 
-//#define SERVER_CERT           NULL
+//#define SERVER_CERTS           NULL
 #define CLIENT_CERT           NULL
 #define CLIENT_PKEY           NULL
 #define CLIENT_PKEY_PASSWORD  0
 
-#ifdef SERVER_CERT
+#define SERVER_CERTIFICATE_COMMON_NAME     "mqtt.liveobjects.orange-business.com"
 
-#define SERVER_CERTIFICATE_COMMON_NAME     NULL
-
-#else
-
-#define SERVER_CERTIFICATE_COMMON_NAME     "liveobjects.orange-business.com"
-
-/*
- * see https://knowledge.symantec.com/support/mpki-for-ssl-support/index?page=content&actp=CROSSLINK&id=SO5624
- */
-const char SERVER_CERT[] = "-----BEGIN CERTIFICATE-----\n"
-		"MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB\n"
-		"yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL\n"
-		"ExZWZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJp\n"
-		"U2lnbiwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxW\n"
-		"ZXJpU2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0\n"
-		"aG9yaXR5IC0gRzUwHhcNMDYxMTA4MDAwMDAwWhcNMzYwNzE2MjM1OTU5WjCByjEL\n"
-		"MAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZW\n"
-		"ZXJpU2lnbiBUcnVzdCBOZXR3b3JrMTowOAYDVQQLEzEoYykgMjAwNiBWZXJpU2ln\n"
-		"biwgSW5jLiAtIEZvciBhdXRob3JpemVkIHVzZSBvbmx5MUUwQwYDVQQDEzxWZXJp\n"
-		"U2lnbiBDbGFzcyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9y\n"
-		"aXR5IC0gRzUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvJAgIKXo1\n"
-		"nmAMqudLO07cfLw8RRy7K+D+KQL5VwijZIUVJ/XxrcgxiV0i6CqqpkKzj/i5Vbex\n"
-		"t0uz/o9+B1fs70PbZmIVYc9gDaTY3vjgw2IIPVQT60nKWVSFJuUrjxuf6/WhkcIz\n"
-		"SdhDY2pSS9KP6HBRTdGJaXvHcPaz3BJ023tdS1bTlr8Vd6Gw9KIl8q8ckmcY5fQG\n"
-		"BO+QueQA5N06tRn/Arr0PO7gi+s3i+z016zy9vA9r911kTMZHRxAy3QkGSGT2RT+\n"
-		"rCpSx4/VBEnkjWNHiDxpg8v+R70rfk/Fla4OndTRQ8Bnc+MUCH7lP59zuDMKz10/\n"
-		"NIeWiu5T6CUVAgMBAAGjgbIwga8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E\n"
-		"BAMCAQYwbQYIKwYBBQUHAQwEYTBfoV2gWzBZMFcwVRYJaW1hZ2UvZ2lmMCEwHzAH\n"
-		"BgUrDgMCGgQUj+XTGoasjY5rw8+AatRIGCx7GS4wJRYjaHR0cDovL2xvZ28udmVy\n"
-		"aXNpZ24uY29tL3ZzbG9nby5naWYwHQYDVR0OBBYEFH/TZafC3ey78DAJ80M5+gKv\n"
-		"MzEzMA0GCSqGSIb3DQEBBQUAA4IBAQCTJEowX2LP2BqYLz3q3JktvXf2pXkiOOzE\n"
-		"p6B4Eq1iDkVwZMXnl2YtmAl+X6/WzChl8gGqCBpH3vn5fJJaCGkgDdk+bW48DW7Y\n"
-		"5gaRQBi5+MHt39tBquCWIMnNZBU4gcmU7qKEKQsTb47bDN0lAtukixlE0kF6BWlK\n"
-		"WE9gyn6CagsCqiUXObXbf+eEZSqVir2G3l6BFoMtEMze/aiCKm0oHw0LxOXnGiYZ\n"
-		"4fQRbxC1lfznQgUy286dUV4otp6F01vvpX1FQHKOtw5rDgb7MzVIcbidJ4vEZV8N\n"
-		"hnacRHr2lVz2XTIIM6RUthg/aFzyQkqFOFSDX9HoLPKsEdao7WNq\n"
-		"-----END CERTIFICATE-----\n";
+#ifndef SERVER_CERTS
+#define SERVER_CERTS "/etc/ssl/certs/ca-certificates.crt"
 #endif
 
 #ifndef CLIENT_CERT


### PR DESCRIPTION
LO ecosystem has a new endpoint for MQTT devices: mqtt.liveobjects.orange-business.com.
Source of root CA certificates has been changed. Now it is set to file containing of concatenated all root CA certificates: /etc/ssl/certs/ca-certificates.crt